### PR TITLE
change point colors to gray if not in LD lookup table

### DIFF
--- a/R/locuscompare.R
+++ b/R/locuscompare.R
@@ -92,7 +92,7 @@ assign_color=function(rsid,snp,ld){
 
     color = data.frame(rsid, stringsAsFactors = FALSE)
     color = merge(color, ld[, c('SNP_B', 'color')], by.x = 'rsid', by.y = 'SNP_B', all.x = TRUE)
-    color[is.na(color$color),'color'] = 'blue4'
+    color[is.na(color$color),'color'] = 'gray'
     if (snp %in% color$rsid){
         color[rsid == snp,'color'] = 'purple'
     } else {


### PR DESCRIPTION
It's confusing to have the color be blue4 (which indicates no LD) if the SNP just wasn't found in the lookup database. I'd suggest making it gray instead