### PR TITLE
Handle extreme small p-values and add logp_col input (#22)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: locuscomparer
 Type: Package
 Title: locuscomparer: Visualization of GWAS-QTL Colocalization Events
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
     person('Boxiang', 'Liu', email = 'jollier.liu@gmail.com', role = c('aut', 'cre')),
     person('Michael', 'Gloudemans', email = 'mgloud@stanford.edu', role = 'ctb'),

--- a/R/locuscompare.R
+++ b/R/locuscompare.R
@@ -5,30 +5,48 @@
 #' @param in_fn (string) Path to the input file.
 #' @param marker_col (string, optional) Name of the marker column. Default: 'rsid'.
 #' @param pval_col (string, optional) Name of the p-value column. Default: 'pval'.
+#' @param logp_col (string, optional) Name of a pre-computed -log10(p-value) column.
+#'   If supplied it is used directly (bypassing the p-value), which avoids the
+#'   underflow that turns extremely small p-values into Inf; `pval` is set to NA.
+#'   Default: NULL.
 #' @examples
 #' in_fn = system.file('extdata', 'gwas.tsv', package = 'locuscomparer')
 #' d1 = read_metal(in_fn, marker_col = 'rsid', pval_col = 'pval')
 #' @export
-read_metal=function(in_fn,marker_col='rsid',pval_col='pval'){
+read_metal=function(in_fn,marker_col='rsid',pval_col='pval',logp_col=NULL){
     # message('Reading ', in_fn)
 
     if (is.character(in_fn)){
-
         d = read.table(in_fn, header = TRUE, stringsAsFactors = FALSE)
-        colnames(d)[which(colnames(d) == marker_col)] = 'rsid'
-        colnames(d)[which(colnames(d) == pval_col)] = 'pval'
-
     } else if (is.data.frame(in_fn)){
-
         d = in_fn
-
     } else {
-
         stop('The argument "in_fn" must be a string or a data.frame')
-
     }
 
-    d$logp = -log10(d$pval)
+    colnames(d)[which(colnames(d) == marker_col)] = 'rsid'
+
+    if (!is.null(logp_col)){
+        if (!logp_col %in% colnames(d)) stop(sprintf('Column "%s" (logp_col) not found.', logp_col))
+        logp = as.numeric(d[[logp_col]])
+        if (any(!is.finite(logp) | logp < 0, na.rm = TRUE)) stop('logp values must be finite and non-negative.')
+        pval = NA_real_
+    } else {
+        if (!pval_col %in% colnames(d)) stop(sprintf('Column "%s" (pval_col) not found.', pval_col))
+        pval = as.numeric(d[[pval_col]])
+        if (any(pval < 0 | pval > 1, na.rm = TRUE)) stop('p-values must be between 0 and 1.')
+        logp = -log10(pval)
+        n_floored = sum(is.infinite(logp))
+        if (n_floored > 0){
+            logp[is.infinite(logp)] = -log10(.Machine$double.xmin)
+            warning(sprintf('%d p-value(s) were 0 (underflow); flooring -log10(p) at %.1f.',
+                            n_floored, -log10(.Machine$double.xmin)))
+        }
+    }
+
+    d$rsid = as.character(d$rsid)
+    d$pval = pval
+    d$logp = logp
     return(d[,c('rsid','pval','logp')])
 }
 
@@ -130,7 +148,13 @@ retrieve_LD = function(chr,snp,population){
 #' @export
 get_lead_snp = function(merged, snp = NULL){
     if (is.null(snp)) {
-        snp = merged[which.min(merged$pval1 + merged$pval2), 'rsid']
+        # Prefer the historical min(pval1 + pval2) rule, but fall back to
+        # max(logp1 + logp2) when p-values are unusable (NA from z-score/logp
+        # input, or 0 from underflow), where the p-value sum would be degenerate.
+        use_pval = !anyNA(merged$pval1) && !anyNA(merged$pval2) &&
+                   all(merged$pval1 > 0) && all(merged$pval2 > 0)
+        snp = if (use_pval) merged[which.min(merged$pval1 + merged$pval2), 'rsid']
+              else          merged[which.max(merged$logp1 + merged$logp2), 'rsid']
     }
     else {
         if (!snp %in% merged$rsid) {

--- a/man/read_metal.Rd
+++ b/man/read_metal.Rd
@@ -6,7 +6,7 @@
 The file must contain 2 columns: markers, i.e SNPs, and p-value.
 The marker column should contain SNP rsIDs.}
 \usage{
-read_metal(in_fn, marker_col = "rsid", pval_col = "pval")
+read_metal(in_fn, marker_col = "rsid", pval_col = "pval", logp_col = NULL)
 }
 \arguments{
 \item{in_fn}{(string) Path to the input file.}
@@ -14,6 +14,11 @@ read_metal(in_fn, marker_col = "rsid", pval_col = "pval")
 \item{marker_col}{(string, optional) Name of the marker column. Default: 'rsid'.}
 
 \item{pval_col}{(string, optional) Name of the p-value column. Default: 'pval'.}
+
+\item{logp_col}{(string, optional) Name of a pre-computed -log10(p-value) column.
+If supplied it is used directly (bypassing the p-value), which avoids the
+underflow that turns extremely small p-values into Inf; \code{pval} is set to NA.
+Default: NULL.}
 }
 \description{
 Read association summary statistics from file and append column.

--- a/tests/testthat/test_get_lead_snp.R
+++ b/tests/testthat/test_get_lead_snp.R
@@ -1,0 +1,33 @@
+context('get_lead_snp lead selection')
+
+test_that('min(pval1+pval2) for clean p-values (backward compatible)', {
+    m = data.frame(rsid = c('a','b','c'),
+                   pval1 = c(0.1, 0.001, 0.5), pval2 = c(0.2, 0.01, 0.5),
+                   logp1 = c(1, 3, 0.3), logp2 = c(0.7, 2, 0.3),
+                   stringsAsFactors = FALSE)
+    expect_equal(get_lead_snp(m), 'b')
+})
+
+test_that('falls back to max(logp1+logp2) when a p-value is 0', {
+    m = data.frame(rsid = c('a','b'),
+                   pval1 = c(0, 0.3), pval2 = c(0.99, 0.3),
+                   logp1 = c(307.6, 0.523), logp2 = c(0.0044, 0.523),
+                   stringsAsFactors = FALSE)
+    # min(pval): b (0.6) < a (0.99) -> 'b';  max(logp): a (307.6) > b (1.05) -> 'a'
+    expect_equal(get_lead_snp(m), 'a')
+})
+
+test_that('falls back to max(logp1+logp2) when p-values are NA (z/logp input)', {
+    m = data.frame(rsid = c('a','b'),
+                   pval1 = NA_real_, pval2 = NA_real_,
+                   logp1 = c(10, 2), logp2 = c(1, 8),
+                   stringsAsFactors = FALSE)
+    expect_equal(get_lead_snp(m), 'a')  # a = 11 > b = 10
+})
+
+test_that('explicit snp is returned and validated', {
+    m = data.frame(rsid = c('a','b'), pval1 = c(0.1, 0.2), pval2 = c(0.1, 0.2),
+                   logp1 = c(1, 0.7), logp2 = c(1, 0.7), stringsAsFactors = FALSE)
+    expect_equal(get_lead_snp(m, 'b'), 'b')
+    expect_error(get_lead_snp(m, 'zzz'), 'not found')
+})

--- a/tests/testthat/test_read_metal_input.R
+++ b/tests/testthat/test_read_metal_input.R
@@ -1,0 +1,25 @@
+context('read_metal flexible input')
+
+test_that('pval == 0 is floored at -log10(xmin) with a warning', {
+    d = data.frame(rsid = c('rs1','rs2'), pval = c(1e-10, 0), stringsAsFactors = FALSE)
+    expect_warning(res <- read_metal(d), 'underflow')
+    expect_true(all(is.finite(res$logp)))
+    expect_equal(res$logp[2], -log10(.Machine$double.xmin))
+})
+
+test_that('normal p-values are unchanged and silent', {
+    d = data.frame(rsid = c('rs1','rs2'), pval = c(0.5, 1e-8), stringsAsFactors = FALSE)
+    expect_silent(res <- read_metal(d))
+    expect_equal(res$logp, -log10(c(0.5, 1e-8)))
+})
+
+test_that('logp_col is used directly and pval becomes NA', {
+    d = data.frame(rsid = c('rs1','rs2'), neglogp = c(5, 320), stringsAsFactors = FALSE)
+    res = read_metal(d, logp_col = 'neglogp')
+    expect_equal(res$logp, c(5, 320))
+    expect_true(all(is.na(res$pval)))
+})
+
+test_that('a missing named column errors clearly', {
+    expect_error(read_metal(data.frame(rsid = 'a', pval = 0.1), logp_col = 'nope'), 'not found')
+})


### PR DESCRIPTION
## Summary
Fixes #22. Extremely significant p-values that underflow to `0` in the input become `-log10(0) = Inf` and break the figure. This PR makes the pipeline robust to that and adds an exact escape hatch.

- **`read_metal()` floors underflowed p-values.** Any `pval == 0` has its `-log10(p)` floored at `-log10(.Machine$double.xmin)` ≈ **307.6**, with a `warning()` reporting how many. Non-zero p-values (even subnormals) are left exact.
- **New `logp_col` argument.** Supply a pre-computed `-log10(p)` column to bypass the p-value round-trip entirely (exact for extreme hits). In this mode `pval` is set to `NA`.
- **`get_lead_snp()` backward-compatible fallback.** Keeps the historical `which.min(pval1+pval2)` when p-values are usable; falls back to `which.max(logp1+logp2)` when a p-value is `NA` (logp input) or `0` (underflow), where the sum would be degenerate. **Normal p-value inputs are unchanged.**

## Tests (all offline)
New `test_read_metal_input.R` and `test_get_lead_snp.R`: zero-flooring + warning, `logp_col` → NA `pval`, missing-column error, and all three lead-SNP branches (min-pval unchanged; 0 and NA fall back to max-logp). Full suite: `FAIL 0 | PASS 19`.

This is the foundational change; z-score input (#9) builds on it next.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)