### PR TITLE
Add z-score input to read_metal() (#9)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: locuscomparer
 Type: Package
 Title: locuscomparer: Visualization of GWAS-QTL Colocalization Events
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: c(
     person('Boxiang', 'Liu', email = 'jollier.liu@gmail.com', role = c('aut', 'cre')),
     person('Michael', 'Gloudemans', email = 'mgloud@stanford.edu', role = 'ctb'),

--- a/R/locuscompare.R
+++ b/R/locuscompare.R
@@ -5,6 +5,9 @@
 #' @param in_fn (string) Path to the input file.
 #' @param marker_col (string, optional) Name of the marker column. Default: 'rsid'.
 #' @param pval_col (string, optional) Name of the p-value column. Default: 'pval'.
+#' @param zscore_col (string, optional) Name of a z-score column. If supplied, the
+#'   two-sided -log10(p-value) is computed from it in a numerically stable way that
+#'   does not underflow for large |z|; `pval` is set to NA. Default: NULL.
 #' @param logp_col (string, optional) Name of a pre-computed -log10(p-value) column.
 #'   If supplied it is used directly (bypassing the p-value), which avoids the
 #'   underflow that turns extremely small p-values into Inf; `pval` is set to NA.
@@ -13,7 +16,7 @@
 #' in_fn = system.file('extdata', 'gwas.tsv', package = 'locuscomparer')
 #' d1 = read_metal(in_fn, marker_col = 'rsid', pval_col = 'pval')
 #' @export
-read_metal=function(in_fn,marker_col='rsid',pval_col='pval',logp_col=NULL){
+read_metal=function(in_fn,marker_col='rsid',pval_col='pval',zscore_col=NULL,logp_col=NULL){
     # message('Reading ', in_fn)
 
     if (is.character(in_fn)){
@@ -26,7 +29,15 @@ read_metal=function(in_fn,marker_col='rsid',pval_col='pval',logp_col=NULL){
 
     colnames(d)[which(colnames(d) == marker_col)] = 'rsid'
 
-    if (!is.null(logp_col)){
+    if (sum(!is.null(zscore_col), !is.null(logp_col)) > 1)
+        stop('Supply only one of zscore_col or logp_col.')
+
+    if (!is.null(zscore_col)){
+        if (!zscore_col %in% colnames(d)) stop(sprintf('Column "%s" (zscore_col) not found.', zscore_col))
+        z = as.numeric(d[[zscore_col]])
+        logp = -(pnorm(-abs(z), log.p = TRUE) + log(2)) / log(10)
+        pval = NA_real_
+    } else if (!is.null(logp_col)){
         if (!logp_col %in% colnames(d)) stop(sprintf('Column "%s" (logp_col) not found.', logp_col))
         logp = as.numeric(d[[logp_col]])
         if (any(!is.finite(logp) | logp < 0, na.rm = TRUE)) stop('logp values must be finite and non-negative.')

--- a/man/read_metal.Rd
+++ b/man/read_metal.Rd
@@ -6,7 +6,8 @@
 The file must contain 2 columns: markers, i.e SNPs, and p-value.
 The marker column should contain SNP rsIDs.}
 \usage{
-read_metal(in_fn, marker_col = "rsid", pval_col = "pval", logp_col = NULL)
+read_metal(in_fn, marker_col = "rsid", pval_col = "pval",
+  zscore_col = NULL, logp_col = NULL)
 }
 \arguments{
 \item{in_fn}{(string) Path to the input file.}
@@ -14,6 +15,10 @@ read_metal(in_fn, marker_col = "rsid", pval_col = "pval", logp_col = NULL)
 \item{marker_col}{(string, optional) Name of the marker column. Default: 'rsid'.}
 
 \item{pval_col}{(string, optional) Name of the p-value column. Default: 'pval'.}
+
+\item{zscore_col}{(string, optional) Name of a z-score column. If supplied, the
+two-sided -log10(p-value) is computed from it in a numerically stable way that
+does not underflow for large |z|; \code{pval} is set to NA. Default: NULL.}
 
 \item{logp_col}{(string, optional) Name of a pre-computed -log10(p-value) column.
 If supplied it is used directly (bypassing the p-value), which avoids the

--- a/tests/testthat/test_read_metal_zscore.R
+++ b/tests/testthat/test_read_metal_zscore.R
@@ -1,0 +1,24 @@
+context('read_metal z-score input')
+
+test_that('zscore_col yields the correct -log10 p (z = 1.96 ~ p 0.05)', {
+    res = read_metal(data.frame(rsid = 'rs1', z = 1.959964, stringsAsFactors = FALSE), zscore_col = 'z')
+    expect_equal(res$logp, -log10(0.05), tolerance = 1e-4)
+    expect_true(is.na(res$pval))
+})
+
+test_that('z-score is sign-agnostic (two-sided)', {
+    res = read_metal(data.frame(rsid = c('a','b'), z = c(5, -5), stringsAsFactors = FALSE), zscore_col = 'z')
+    expect_equal(res$logp[1], res$logp[2])
+})
+
+test_that('large z stays finite (no Inf underflow)', {
+    res = read_metal(data.frame(rsid = 'a', z = 50, stringsAsFactors = FALSE), zscore_col = 'z')
+    expect_true(is.finite(res$logp) && res$logp > 500)
+})
+
+test_that('cannot supply both zscore_col and logp_col', {
+    expect_error(
+        read_metal(data.frame(rsid = 'a', z = 1, lp = 1, stringsAsFactors = FALSE),
+                   zscore_col = 'z', logp_col = 'lp'),
+        'only one')
+})


### PR DESCRIPTION
## Summary
Fixes #9. `read_metal()` can now take a **z-score** column instead of a p-value.

- New `zscore_col` argument. The two-sided `-log10(p)` is computed **directly and stably** from z:
  ```r
  logp <- -(pnorm(-abs(z), log.p = TRUE) + log(2)) / log(10)
  ```
  This never underflows — a z of 50 yields `logp ≈ 545`, not `Inf` (the naive `2*pnorm(-|z|)` would be `0`).
- `pval` is set to `NA`, so lead-SNP selection uses the `max(logp)` fallback added in #22.
- `zscore_col` and `logp_col` are mutually exclusive (clear error otherwise).

Builds on #37 (the shared `logp`/fallback machinery).

## Tests (offline)
`test_read_metal_zscore.R`: z=1.96 → logp≈1.30; sign-agnostic (`logp(z)==logp(-z)`); large z stays finite; both-columns error. Full suite: `FAIL 0 | PASS 24`.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)