### PR TITLE
Allow user-supplied LD in locuscompare() (#12, #20)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: locuscomparer
 Type: Package
 Title: locuscomparer: Visualization of GWAS-QTL Colocalization Events
-Version: 1.0.2
+Version: 1.1.0
 Authors@R: c(
     person('Boxiang', 'Liu', email = 'jollier.liu@gmail.com', role = c('aut', 'cre')),
     person('Michael', 'Gloudemans', email = 'mgloud@stanford.edu', role = 'ctb'),

--- a/R/locuscompare.R
+++ b/R/locuscompare.R
@@ -413,6 +413,10 @@ make_combined_plot = function (merged, title1, title2, ld, chr, snp = NULL,
 #' @param legend_position (string, optional) Either 'bottomright','topright', or 'topleft'. Default: 'bottomright'.
 #' @param lz_ylab_linebreak (boolean, optional) Whether to break the line of y-axis of the locuszoom plot.
 #' @param genome (string, optional) Genome assembly, either 'hg19' or 'hg38'. Default: 'hg19'.
+#' @param ld (data.frame, optional) Supply your own LD instead of querying the reference
+#'   database: a data.frame with columns SNP_A, SNP_B, R2, where SNP_A is the lead `snp`.
+#'   When given, `retrieve_LD()` is skipped and `population` is ignored; `snp` is required.
+#'   Default: NULL.
 #' @examples
 #' in_fn1 = system.file('extdata','gwas.tsv', package = 'locuscomparer')
 #' in_fn2 = system.file('extdata','eqtl.tsv', package = 'locuscomparer')
@@ -422,7 +426,17 @@ locuscompare = function(in_fn1, in_fn2, marker_col1 = "rsid", pval_col1 = "pval"
                  title1 = "eQTL",marker_col2 = "rsid", pval_col2 = "pval", title2 = "GWAS",
                  snp = NULL, population = "EUR", combine = TRUE, legend = TRUE,
                  legend_position = c('bottomright','topright','topleft'),
-                 lz_ylab_linebreak = FALSE, genome = c('hg19','hg38')) {
+                 lz_ylab_linebreak = FALSE, genome = c('hg19','hg38'), ld = NULL) {
+
+    if (!is.null(ld)) {
+        if (is.null(snp))
+            stop("When supplying 'ld', you must also specify the lead 'snp' the LD is relative to.")
+        if (!is.data.frame(ld) || !all(c('SNP_A','SNP_B','R2') %in% colnames(ld)))
+            stop("'ld' must be a data.frame with columns SNP_A, SNP_B, R2.")
+        if (!snp %in% ld$SNP_A)
+            warning(sprintf("None of the supplied LD rows have SNP_A == '%s'; all SNPs will be colored as low-LD.", snp))
+    }
+
     d1 = read_metal(in_fn1, marker_col1, pval_col1)
     d2 = read_metal(in_fn2, marker_col2, pval_col2)
 
@@ -434,7 +448,7 @@ locuscompare = function(in_fn1, in_fn2, marker_col1 = "rsid", pval_col1 = "pval"
     if (length(chr) != 1) stop('There must be one and only one chromosome.')
 
     snp = get_lead_snp(merged, snp)
-    ld = retrieve_LD(chr, snp, population)
+    if (is.null(ld)) ld = retrieve_LD(chr, snp, population)
     p = make_combined_plot(merged, title1, title2, ld, chr, snp, combine,
                            legend, legend_position, lz_ylab_linebreak)
     return(p)

--- a/man/locuscompare.Rd
+++ b/man/locuscompare.Rd
@@ -8,7 +8,8 @@ locuscompare(in_fn1, in_fn2, marker_col1 = "rsid", pval_col1 = "pval",
   title1 = "eQTL", marker_col2 = "rsid", pval_col2 = "pval",
   title2 = "GWAS", snp = NULL, population = "EUR", combine = TRUE,
   legend = TRUE, legend_position = c("bottomright", "topright",
-  "topleft"), lz_ylab_linebreak = FALSE, genome = c("hg19", "hg38"))
+  "topleft"), lz_ylab_linebreak = FALSE, genome = c("hg19", "hg38"),
+  ld = NULL)
 }
 \arguments{
 \item{in_fn1}{(string) Path to the input file for study 1.}
@@ -41,6 +42,11 @@ three plots will be returned. Default: TRUE.}
 \item{lz_ylab_linebreak}{(boolean, optional) Whether to break the line of y-axis of the locuszoom plot.}
 
 \item{genome}{(string, optional) Genome assembly, either 'hg19' or 'hg38'. Default: 'hg19'.}
+
+\item{ld}{(data.frame, optional) Supply your own LD instead of querying the reference
+database: a data.frame with columns SNP_A, SNP_B, R2, where SNP_A is the lead \code{snp}.
+When given, \code{retrieve_LD()} is skipped and \code{population} is ignored; \code{snp}
+is required. Default: NULL.}
 }
 \description{
 Make a locuscompare plot.

--- a/tests/testthat/test_custom_ld.R
+++ b/tests/testthat/test_custom_ld.R
@@ -1,0 +1,18 @@
+context('locuscompare custom LD')
+
+test_that('supplying ld without snp errors', {
+    ld = data.frame(SNP_A = 'rs1', SNP_B = 'rs2', R2 = 0.5, stringsAsFactors = FALSE)
+    expect_error(locuscompare('a.tsv', 'b.tsv', ld = ld), "specify the lead 'snp'")
+})
+
+test_that('malformed ld (missing required columns) errors', {
+    bad = data.frame(A = 'rs1', B = 'rs2', r2 = 0.5, stringsAsFactors = FALSE)
+    expect_error(locuscompare('a.tsv', 'b.tsv', snp = 'rs1', ld = bad), 'SNP_A, SNP_B, R2')
+})
+
+test_that('ld whose SNP_A never matches the lead snp warns', {
+    ld = data.frame(SNP_A = 'rsX', SNP_B = 'rsY', R2 = 0.5, stringsAsFactors = FALSE)
+    expect_warning(
+        tryCatch(locuscompare('a.tsv', 'b.tsv', snp = 'rs1', ld = ld), error = function(e) NULL),
+        'low-LD')
+})


### PR DESCRIPTION
## Summary
Fixes #12 and #20. `locuscompare()` can now take a **user-supplied LD** table instead of querying the reference database — enabling custom reference panels and multi-ancestry analyses.

- New `ld` argument: a `data.frame(SNP_A, SNP_B, R2)` where `SNP_A` is the lead SNP. When supplied, `retrieve_LD()` is **skipped** and `population` is ignored.
- Because the LD is relative to a specific lead, **`snp` is required** when `ld` is given (clear error otherwise).
- Malformed `ld` (missing columns) errors; an `ld` whose `SNP_A` never matches the lead **warns** that all points will render as low-LD.
- Default behavior (reference DB) is completely unchanged.

```r
# bring your own LD (e.g. PLINK --ld-snp <lead> --r2 on a custom panel)
locuscompare(gwas, eqtl, snp = "rs9349379", ld = my_ld)   # my_ld: SNP_A/SNP_B/R2
```

## Tests
Offline: `ld`-without-`snp` error, malformed-`ld` error, unmatched-lead warning. Plus a manual end-to-end smoke test (positions from DB, coloring from supplied r²) returns a valid ggplot. Full suite: `FAIL 0 | PASS 27`.

Closes #12
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)