### PR TITLE
docs: NEWS.md + README News section for v1.1.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,29 @@
+# Version 1.1.0:
+
+## New features
+* `read_metal()` now accepts a z-score column via `zscore_col`, computing a
+  numerically stable two-sided -log10(p) that never underflows to `Inf` for
+  extremely significant values (#9).
+* `read_metal()` now accepts a pre-computed `-log10(p)` column via `logp_col`,
+  and p-values that underflow to `0` are floored (with a warning) instead of
+  producing `Inf` (#22).
+* `locuscompare()` gains an `ld` argument for supplying your own LD table
+  (`SNP_A` / `SNP_B` / `R2`), bypassing the reference database -- useful for
+  custom or multi-ancestry reference panels (#12, #20).
+
+## Bug fixes
+* The lead SNP is now reliably drawn as the purple diamond; a row-ordering bug
+  in `assign_color()` could color the wrong SNP (#30).
+* Fixed the broken `get_lead_snp()` / `get_position()` examples and the
+  malformed `DESCRIPTION` `Authors@R` field so the package passes `R CMD check`
+  (#13).
+
+## Infrastructure
+* The LD and position database has moved to a new server; reinstall to pick up
+  the new connection settings (#35).
+
+# Version 1.0.0:
+Much faster LD calculation (querying a MySQL database).
+
+# Version 0.1.0:
+Calculating LD on the fly using PLINK and 1000 Genomes files.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # LocusCompareR
 
+## News
+
+**v1.1.0** — `read_metal()` now accepts z-scores (`zscore_col`) and pre-computed `-log10(p)` (`logp_col`), and gracefully floors p-values that underflow to `0`; `locuscompare()` accepts a user-supplied LD table via `ld=` for custom or multi-ancestry panels. See [NEWS.md](NEWS.md) for the full changelog.
+
 ## 1. Installation
 LocusCompareR is an R package for visualization of GWAS-eQTL colocalization events. 
 

--- a/news.md
+++ b/news.md
@@ -1,7 +1,0 @@
-# Version 0.1.0:
-Calculating LD on the fly using PLINK and 1000 Genomes files.
-
-# Version 1.0.0:
-Much faster LD calculation (querying a MySQL database).
-
-


### PR DESCRIPTION
Renames `news.md` → `NEWS.md` (standard R changelog filename), adds a **1.1.0** entry (z-score/logp input #9/#22, custom LD #12/#20, coloring fix #30, example+DESCRIPTION fixes #13, DB migration #35), and adds a **News** section to the README linking to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)