### PR TITLE
docs: date the 1.1.0 changelog entry

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# Version 1.1.0:
+# Version 1.1.0 (2026-07-08):
 
 ## New features
 * `read_metal()` now accepts a z-score column via `zscore_col`, computing a


### PR DESCRIPTION
Adds the release date to the NEWS.md 1.1.0 header (`# Version 1.1.0 (2026-07-08):`), per changelog convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)